### PR TITLE
Use access_token as a header instead of request param

### DIFF
--- a/utils/api_requests.py
+++ b/utils/api_requests.py
@@ -29,16 +29,16 @@ def get_listings_single(connectedRealmId: int, access_token: str, region: str):
     print("==========================================")
     print(f"gather data from connectedRealmId {connectedRealmId} of region {region}")
     if region == "NA":
-        url = f"https://us.api.blizzard.com/data/wow/connected-realm/{str(connectedRealmId)}/auctions?namespace=dynamic-us&locale=en_US&access_token={access_token}"
+        url = f"https://us.api.blizzard.com/data/wow/connected-realm/{str(connectedRealmId)}/auctions?namespace=dynamic-us&locale=en_US"
     elif region == "EU":
-        url = f"https://eu.api.blizzard.com/data/wow/connected-realm/{str(connectedRealmId)}/auctions?namespace=dynamic-eu&locale=en_EU&access_token={access_token}"
+        url = f"https://eu.api.blizzard.com/data/wow/connected-realm/{str(connectedRealmId)}/auctions?namespace=dynamic-eu&locale=en_EU"
     else:
         print(
             f"{region} is not yet supported, reach out for us to add this region option"
         )
         exit(1)
 
-    req = requests.get(url, timeout=20)
+    req = requests.get(url, timeout=20, headers={"access_token":access_token})
 
     auction_info = req.json()
     return auction_info["auctions"]
@@ -85,7 +85,8 @@ def get_itemnames():
 def get_petnames(client_id, client_secret):
     access_token = get_wow_access_token(client_id, client_secret)
     pet_info = requests.get(
-        f"https://us.api.blizzard.com/data/wow/pet/index?namespace=static-us&locale=en_US&access_token={access_token}"
+        f"https://us.api.blizzard.com/data/wow/pet/index?namespace=static-us&locale=en_US",
+        headers={"access_token":access_token},
     ).json()["pets"]
     pet_info = {pet["id"]: pet["name"] for pet in pet_info}
     return pet_info

--- a/utils/api_requests.py
+++ b/utils/api_requests.py
@@ -85,8 +85,8 @@ def get_itemnames():
 def get_petnames(client_id, client_secret):
     access_token = get_wow_access_token(client_id, client_secret)
     pet_info = requests.get(
-        f"https://us.api.blizzard.com/data/wow/pet/index?namespace=static-us&locale=en_US",
-        headers={"access_token":access_token},
+        "https://us.api.blizzard.com/data/wow/pet/index?namespace=static-us&locale=en_US",
+        headers={"Authorization": f"Bearer {access_token}"},
     ).json()["pets"]
     pet_info = {pet["id"]: pet["name"] for pet in pet_info}
     return pet_info

--- a/utils/api_requests.py
+++ b/utils/api_requests.py
@@ -38,7 +38,7 @@ def get_listings_single(connectedRealmId: int, access_token: str, region: str):
         )
         exit(1)
 
-    req = requests.get(url, timeout=20, headers={"access_token":access_token})
+    req = requests.get(url, timeout=20, headers={"Authorization": f"Bearer {access_token}"})
 
     auction_info = req.json()
     return auction_info["auctions"]

--- a/utils/mega_data_setup.py
+++ b/utils/mega_data_setup.py
@@ -171,7 +171,8 @@ class MegaData:
 
     def __set_pet_names(self):
         pet_info = requests.get(
-            f"https://us.api.blizzard.com/data/wow/pet/index?namespace=static-us&locale=en_US&access_token={self.access_token}"
+            f"https://us.api.blizzard.com/data/wow/pet/index?namespace=static-us&locale=en_US",
+            headers={"access_token":self.access_token},
         ).json()["pets"]
         pet_info = {int(pet["id"]): pet["name"] for pet in pet_info}
         return pet_info
@@ -352,16 +353,16 @@ class MegaData:
         # we want to use check_access_token here to update the token when expired
         if self.REGION == "NA":
             url = f"https://us.api.blizzard.com/data/wow/connected-realm/{str(connectedRealmId)}"
-            url += f"/auctions?namespace=dynamic-us&locale=en_US&access_token={self.check_access_token()}"
+            url += f"/auctions?namespace=dynamic-us&locale=en_US"
         elif self.REGION == "EU":
             url = f"https://eu.api.blizzard.com/data/wow/connected-realm/{str(connectedRealmId)}"
-            url += f"/auctions?namespace=dynamic-eu&locale=en_EU&access_token={self.check_access_token()}"
+            url += f"/auctions?namespace=dynamic-eu&locale=en_EU"
         else:
             raise Exception(
                 f"{self.REGION} is not yet supported, reach out for us to add this region option"
             )
 
-        req = requests.get(url, timeout=20)
+        req = requests.get(url, timeout=20, headers={"access_token":self.check_access_token()})
         # check for api errors
         if req.status_code == 429:
             print(


### PR DESCRIPTION
Fixes #48 

This is untested as I couldn't find a test suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced security for API requests by moving the access token from the URL to request headers.

- **Bug Fixes**
	- Improved error handling and retry mechanisms for API requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->